### PR TITLE
small fixes

### DIFF
--- a/dhgroup/dh.go
+++ b/dhgroup/dh.go
@@ -58,7 +58,7 @@ func (g *GroupParams) DHParams() *GroupParams {
 }
 
 func (g GroupParams) GenerateKey(rng io.Reader) (DHKey, error) {
-
+	panic("Not implemented")
 	return DHKey{
 		Private: nil,
 		Public:  nil,
@@ -104,7 +104,7 @@ func initMODP768() {
 		"EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245" +
 		"E485B576625E7EC6F44C42E9A63A3620FFFFFFFFFFFFFFFF")
 	modp768.G = big.NewInt(2)
-	modp768.Q = nil
+	modp768.Q = new(big.Int).Sub(modp768.P, big.NewInt(1))
 	modp768.BitSize = 768
 }
 
@@ -120,7 +120,7 @@ func initMODP1536() {
 		"bb9ed529077096966d670c354e4abc9804f1746c08ca237327fff" +
 		"fffffffffffff")
 	modp1536.G = big.NewInt(2)
-	modp1536.Q = nil
+	modp1536.Q = new(big.Int).Sub(modp1536.P, big.NewInt(1))
 	modp1536.BitSize = 1536
 }
 
@@ -138,7 +138,7 @@ func initMODP2048() {
 		"DE2BCBF6955817183995497CEA956AE515D2261898FA0510" +
 		"15728E5A8AACAA68FFFFFFFFFFFFFFFF")
 	modp2048.G = big.NewInt(2)
-	modp2048.Q = nil
+	modp2048.Q = new(big.Int).Sub(modp2048.P, big.NewInt(1))
 	modp2048.BitSize = 2048
 }
 

--- a/dhgroup/dh_test.go
+++ b/dhgroup/dh_test.go
@@ -2,6 +2,7 @@ package dhgroup
 
 import (
 	"bytes"
+	"crypto/rand"
 	"testing"
 )
 
@@ -10,13 +11,13 @@ func TestDH(t *testing.T) {
 		g, _ := GroupForGroupID(v)
 
 		// Alice generates a key pair.
-		a, err := g.GenerateKey(nil)
+		a, err := g.GenerateKey(rand.Reader)
 		if err != nil {
 			t.Errorf("%s: Alice key generation failed for %s", t.Name(), g.DHName())
 		}
 
 		// Bog generates a key pair.
-		b, err := g.GenerateKey(nil)
+		b, err := g.GenerateKey(rand.Reader)
 		if err != nil {
 			t.Errorf("%s: Bob key generation failed for %s", t.Name(), g.DHName())
 		}

--- a/elliptic/elliptic.go
+++ b/elliptic/elliptic.go
@@ -42,7 +42,7 @@ func (curve *CurveParams) Params() *CurveParams {
 }
 
 func (curve *CurveParams) IsOnCurve(x, y *big.Int) bool {
-	// y^2 = x^3 - a*x + b
+	// y^2 = x^3 + a*x + b
 	panic("not implemented")
 	return false
 }
@@ -176,7 +176,7 @@ func initP256() {
 	p256.P, _ = new(big.Int).SetString("115792089210356248762697446949407573530086143415290314195533631308867097853951", 10)
 	p256.N, _ = new(big.Int).SetString("115792089210356248762697446949407573529996955224135760342422259061068512044369", 10)
 	p256.B, _ = new(big.Int).SetString("5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b", 16)
-	p256.A, _ = new(big.Int).SetString("3", 10)
+	p256.A, _ = new(big.Int).SetString("-3", 10)
 	p256.Gx, _ = new(big.Int).SetString("6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296", 16)
 	p256.Gy, _ = new(big.Int).SetString("4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5", 16)
 	p256.BitSize = 127
@@ -188,7 +188,7 @@ func initP224() {
 	p224.P, _ = new(big.Int).SetString("26959946667150639794667015087019630673557916260026308143510066298881", 10)
 	p224.N, _ = new(big.Int).SetString("26959946667150639794667015087019625940457807714424391721682722368061", 10)
 	p224.B, _ = new(big.Int).SetString("b4050a850c04b3abf54132565044b0b7d7bfd8ba270b39432355ffb4", 16)
-	p224.A, _ = new(big.Int).SetString("3", 10)
+	p224.A, _ = new(big.Int).SetString("-3", 10)
 	p224.Gx, _ = new(big.Int).SetString("b70e0cbd6bb4bf7f321390b94a03c1d356c21122343280d6115c1d21", 16)
 	p224.Gy, _ = new(big.Int).SetString("bd376388b5f723fb4c22dfe6cd4375a05a07476444d5819985007e34", 16)
 	p224.BitSize = 224
@@ -198,7 +198,7 @@ func initP4() {
 	p4 = &CurveParams{Name: "P-4"}
 	p4.P, _ = new(big.Int).SetString("11", 10)
 	p4.B, _ = new(big.Int).SetString("1", 10)
-	p4.A, _ = new(big.Int).SetString("3", 10)
+	p4.A, _ = new(big.Int).SetString("-3", 10)
 	p4.BitSize = 4
 }
 
@@ -207,7 +207,7 @@ func initP128() {
 	p128.P, _ = new(big.Int).SetString("233970423115425145524320034830162017933", 10)
 	p128.N, _ = new(big.Int).SetString("29246302889428143187362802287225875743", 10)
 	p128.B, _ = new(big.Int).SetString("11279326", 10)
-	p128.A, _ = new(big.Int).SetString("95051", 10)
+	p128.A, _ = new(big.Int).SetString("-95051", 10)
 	p128.Gx, _ = new(big.Int).SetString("182", 10)
 	p128.Gy, _ = new(big.Int).SetString("85518893674295321206118380980485522083", 10)
 	p128.BitSize = 128
@@ -218,7 +218,7 @@ func initP128V1() {
 	p128v1.P, _ = new(big.Int).SetString("233970423115425145524320034830162017933", 10)
 	p128v1.N, _ = new(big.Int).SetString("233970423115425145550826547352470124412", 10)
 	p128v1.B, _ = new(big.Int).SetString("210", 10)
-	p128v1.A, _ = new(big.Int).SetString("95051", 10)
+	p128v1.A, _ = new(big.Int).SetString("-95051", 10)
 	p128v1.Gx, _ = new(big.Int).SetString("182", 10)
 	p128v1.Gy, _ = new(big.Int).SetString("85518893674295321206118380980485522083", 10)
 	p128v1.BitSize = 128
@@ -229,7 +229,7 @@ func initP128V2() {
 	p128v2.P, _ = new(big.Int).SetString("233970423115425145524320034830162017933", 10)
 	p128v2.N, _ = new(big.Int).SetString("233970423115425145544350131142039591210", 10)
 	p128v2.B, _ = new(big.Int).SetString("504", 10)
-	p128v2.A, _ = new(big.Int).SetString("95051", 10)
+	p128v2.A, _ = new(big.Int).SetString("-95051", 10)
 	p128v2.Gx, _ = new(big.Int).SetString("182", 10)
 	p128v2.Gy, _ = new(big.Int).SetString("85518893674295321206118380980485522083", 10)
 	p128v2.BitSize = 128
@@ -240,7 +240,7 @@ func initP128V3() {
 	p128v3.P, _ = new(big.Int).SetString("233970423115425145524320034830162017933", 10)
 	p128v3.N, _ = new(big.Int).SetString("233970423115425145545378039958152057148", 10)
 	p128v3.B, _ = new(big.Int).SetString("727", 10)
-	p128v3.A, _ = new(big.Int).SetString("95051", 10)
+	p128v3.A, _ = new(big.Int).SetString("-95051", 10)
 	p128v3.Gx, _ = new(big.Int).SetString("182", 10)
 	p128v3.Gy, _ = new(big.Int).SetString("85518893674295321206118380980485522083", 10)
 	p128v3.BitSize = 128
@@ -251,7 +251,7 @@ func initP48() {
 	p48.P, _ = new(big.Int).SetString("146150163733117", 10)
 	p48.N, _ = new(big.Int).SetString("146150168402890", 10)
 	p48.B, _ = new(big.Int).SetString("1242422", 10)
-	p48.A = new(big.Int).Sub(p48.P, big.NewInt(544333))
+	p48.A, _ = new(big.Int).SetString("544333", 10 )
 	p48.Gx, _ = new(big.Int).SetString("27249639878388", 10)
 	p48.Gy, _ = new(big.Int).SetString("14987583413657", 10)
 	p48.BitSize = 48

--- a/kciattacks.go
+++ b/kciattacks.go
@@ -1,6 +1,7 @@
 package dhpals
 
 import (
+	"crypto/rand"
 	"fmt"
 	"math/big"
 
@@ -9,8 +10,8 @@ import (
 
 func runKCIAttack() ([]byte, error) {
 	var dhGroup, _ = dhgroup.GroupForGroupID(dhgroup.ModP2048)
-	static, _ := dhGroup.GenerateKey(nil)
-	ephemeral, _ := dhGroup.GenerateKey(nil)
+	static, _ := dhGroup.GenerateKey(rand.Reader)
+	ephemeral, _ := dhGroup.GenerateKey(rand.Reader)
 
 	kem := dhkemScheme{group: dhGroup}
 

--- a/oracle.go
+++ b/oracle.go
@@ -5,6 +5,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -33,7 +34,7 @@ func newDHOracle(id dhgroup.ID) (
 
 	var dhGroup, _ = dhgroup.GroupForGroupID(id)
 
-	dhKey, _ := dhGroup.GenerateKey(nil)
+	dhKey, _ := dhGroup.GenerateKey(rand.Reader)
 
 	dh = func(publicKey *big.Int) []byte {
 		sharedKey, err := dhGroup.DH(dhKey.Private, publicKey)
@@ -125,7 +126,7 @@ func newToxOracle(id dhgroup.ID) (
 	getPrivate func() []byte,
 ) {
 	var dhGroup, _ = dhgroup.GroupForGroupID(id)
-	static, _ := dhGroup.GenerateKey(nil)
+	static, _ := dhGroup.GenerateKey(rand.Reader)
 	var key []byte
 
 	pubKeys := make(map[string][]byte)
@@ -156,7 +157,7 @@ func newToxOracle(id dhgroup.ID) (
 
 		peerPublicEphemeral := kem.Decap(static.Private, new(big.Int).SetBytes(peerPublicStatic), payload)
 
-		ephemeral, _ := dhGroup.GenerateKey(nil)
+		ephemeral, _ := dhGroup.GenerateKey(rand.Reader)
 		ct := kem.Encap(static.Private, new(big.Int).SetBytes(peerPublicStatic), ephemeral.Public.Bytes())
 
 		key = new(big.Int).Exp(new(big.Int).SetBytes(peerPublicEphemeral), ephemeral.Private, dhGroup.DHParams().P).Bytes()


### PR DESCRIPTION
1. Во всех вызовах функции `GenerateKey` в качестве источника рандома передается `rand.Reader` вместо `nil`
2. В группах, где порядок группы совпадает с порядком генератора, параметр Q выставлен в p - 1 для удобства (вместо `nil`)
3. В `GenerateKey` добавлена паника. Предыдущее возвращаемое значение оставлено намеренно, чтобы иметь пример того, как оно должно выглядеть
4. Исправлена ошибка в параметре А для эллиптических кривых (-А заменен на А)